### PR TITLE
feat!: bump ArgoCD CLI to `v3.0.6`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: >
       Version of Argo CD to install - https://github.com/argoproj/argo-cd/releases
     required: false
-    default: 2.13.3
+    default: 3.0.6
 
 runs:
   using: node20


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Bump default ArgoCD CLI version to the latest stable v3.0.6

Note: semantic release will bump major version after merge

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
