### PR TITLE
feat: Bump default ArgoCD version to `v3.1.5`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: >
       Version of Argo CD to install - https://github.com/argoproj/argo-cd/releases
     required: false
-    default: 3.0.6
+    default: 3.1.5
 
 runs:
   using: node20


### PR DESCRIPTION
## Description
Bump default ArgoCD CLI version to the latest stable v3.1.5

Note: semantic release will bump major version after merge

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):
